### PR TITLE
refactor(redis): separate cached and blacklisted token storage

### DIFF
--- a/gateway/src/main/java/com/example/gateway/config/RedisCacheConfig.java
+++ b/gateway/src/main/java/com/example/gateway/config/RedisCacheConfig.java
@@ -36,6 +36,11 @@ public class RedisCacheConfig {
                         RedisSerializationContext.SerializationPair.fromSerializer(
                                 new Jackson2JsonRedisSerializer<>(Map.class))));
 
+        cacheConfigurations.put("blacklistedTokens", defaultConfig.serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                        new Jackson2JsonRedisSerializer<>(Map.class))));
+
+
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(defaultConfig) // Default settings
                 .withInitialCacheConfigurations(cacheConfigurations) // Custom per-cache configurations

--- a/gateway/src/main/java/com/example/gateway/services/AuthService.java
+++ b/gateway/src/main/java/com/example/gateway/services/AuthService.java
@@ -34,8 +34,10 @@ public class AuthService {
     public Mono<ResponseEntity<Map<String, Object>>> validateToken(String token) {
 
 
-        if (isTokenBlacklisted(token)) {
-            log.warn("🚫 Token is blacklisted: {}", token);
+        String redisBlacklistKey = "blacklist::" + token;
+
+        if (isTokenBlacklisted(redisBlacklistKey)) {
+            log.warn("🚫 Token is blacklisted: {}", redisBlacklistKey);
             return Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Unauthorized", "message", "Token is logged out")));
         }
 

--- a/userService/src/main/java/com/example/config/RedisCacheConfig.java
+++ b/userService/src/main/java/com/example/config/RedisCacheConfig.java
@@ -31,10 +31,11 @@ public class RedisCacheConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 
         // Cache configuration for Tokens
-        cacheConfigurations.put("token",
-                defaultConfig.serializeValuesWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(
-                                new Jackson2JsonRedisSerializer<>(Map.class))));
+
+        cacheConfigurations.put("blacklistedTokens", defaultConfig.serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                        new Jackson2JsonRedisSerializer<>(Map.class))));
+
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(defaultConfig) // Default settings

--- a/userService/src/main/java/com/example/services/TokenBlacklistService.java
+++ b/userService/src/main/java/com/example/services/TokenBlacklistService.java
@@ -26,7 +26,8 @@ public class TokenBlacklistService {
         token = token.startsWith("Bearer ")
                 ? token.substring(7)
                 : token;
-        redisTemplate.opsForValue().set(token, new HashMap<>(), blacklistExpirationTime, TimeUnit.SECONDS);
+        String redisKey = "blacklist::" + token;
+        redisTemplate.opsForValue().set(redisKey, new HashMap<>(), blacklistExpirationTime, TimeUnit.SECONDS);
     }
 
     // Check if a token is blacklisted


### PR DESCRIPTION
- Introduced distinct Redis cache names: 'cachedTokens' for active tokens and 'blacklistedTokens' for revoked tokens.
- Updated RedisCacheManager configuration in gateway and user service.
- Prevents conflicts and accidental misuse of token keys in shared Redis storage.
- Ensures better separation of concerns between authentication and revocation logic.